### PR TITLE
Fix build for testing isolated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ "3.8", "3.9", "3.10" ]
 
@@ -74,7 +75,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.8'
         architecture: 'x64'
     - uses: actions/download-artifact@v2
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "jupyter_server>=1.6,<3"
+    "jupyter_server>=1.6,<3",
+    "ebrains-drive>=0.5.0"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
@@ -33,7 +34,8 @@ test = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
-    "pytest-tornasync"
+    "pytest-tornasync",
+    "pytest-mock"
 ]
 
 [tool.hatch.version]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,1 @@
-__import__('setuptools').setup(
-    install_requires=[
-        "ebrains-drive >= 0.5.0"
-    ])
+__import__('setuptools').setup()


### PR DESCRIPTION
Dependencies should be listed in `pyproject.toml`, this is a newer standard replacing the now deprecated `setuptools`.